### PR TITLE
Add visualization of modifier structure

### DIFF
--- a/src/components/AnalysisDetails.vue
+++ b/src/components/AnalysisDetails.vue
@@ -12,7 +12,12 @@
   <div style="text-align:center;">
     <h2>Systematic Variations</h2>
   </div>
-  <ModifierStructurePlot :channels="workspace.workspace.channels" />
+  <span class="detailbutton" @click="toggleModifierStructureView()"><h2 v-if="!isModifierStructureView()">Show Modifier Structure</h2><h2 v-else>Hide Modifier Structure</h2></span>
+  <Transition>
+    <span v-if="isModifierStructureView()">
+      <ModifierStructurePlot :channels="workspace.workspace.channels" />
+    </span>
+  </Transition>
   <div style="text-align:center;">
     <input type="text" v-model="systFilter" placeholder="Filter Systematic Variations" />
     <input type="number" min=0 :max="parseInt(systnames.length/10)" v-model="systPage" placeholder="Switch systematics" />
@@ -50,7 +55,8 @@ export default {
     return {
       systFilter: '',
       systPage: 0,
-      channelNames: []
+      channelNames: [],
+      modifierStructureView: false
     }
   },
   computed: {
@@ -77,6 +83,12 @@ export default {
       for (const c of this.inputData) {
         this.channelNames.push(c.name)
       }
+    },
+    toggleModifierStructureView () {
+      this.modifierStructureView = !this.modifierStructureView
+    },
+    isModifierStructureView () {
+      return this.modifierStructureView
     }
   },
   beforeMount () {

--- a/src/components/AnalysisDetails.vue
+++ b/src/components/AnalysisDetails.vue
@@ -11,6 +11,9 @@
   <br>
   <div style="text-align:center;">
     <h2>Systematic Variations</h2>
+  </div>
+  <ModifierStructurePlot :channels="workspace.workspace.channels" />
+  <div style="text-align:center;">
     <input type="text" v-model="systFilter" placeholder="Filter Systematic Variations" />
     <input type="number" min=0 :max="parseInt(systnames.length/10)" v-model="systPage" placeholder="Switch systematics" />
   </div>
@@ -26,6 +29,7 @@
 </template>
 
 <script>
+import ModifierStructurePlot from './ModifierStructurePlot.vue'
 import PieChart from './PieChart.vue'
 import StackedPlot from './StackedPlot.vue'
 import SystDataPlot from './SystDataPlot.vue'
@@ -33,7 +37,8 @@ export default {
   components: {
     PieChart,
     StackedPlot,
-    SystDataPlot
+    SystDataPlot,
+    ModifierStructurePlot
   },
   props: {
     processNames: Array,

--- a/src/components/ModifierStructurePlot.vue
+++ b/src/components/ModifierStructurePlot.vue
@@ -1,0 +1,90 @@
+<template>
+  <template v-for="channel in channels" :key="channel.name">
+    <h2>{{channel.name}}</h2>
+    <svg :height="length*modifiertypes[channel.name].length" :width="length*modifiernames.length">
+      <template v-for="(process, processIndex) in modifiertypes[channel.name]" :key="process.name">
+        <rect v-for="(modifiername, modifierIndex) in modifiernames" :key="modifiername" :height="length" :width="length" :x="modifierIndex*length" :y="processIndex*length" :fill="colors[process.types[modifiername]]"/>
+      </template>
+    </svg>
+    <hr />
+  </template>
+</template>
+
+<script>
+export default {
+  props: {
+    channels: Array
+  },
+  data () {
+    return {
+      length: 20
+    }
+  },
+  computed: {
+    colors () {
+      // use the same color scheme as cabinetry
+      const modifierColor = {
+        lumi: 'rgb(85,85,85)', // dark gray
+        staterror: 'rgb(230,159,0)', // orange
+        normsys: 'rgb(86,180,233)', // sky blue
+        histosys: 'rgb(240,228,66)', // yellow
+        none: 'rgb(255,255,255)', // white
+        normhisto: 'rgb(0,158,115)', // blueish green
+        shapesys: 'rgb(204,121,167)', // reddish purple
+        normfactor: 'rgb(213,94,0)' // vermilion
+      }
+      return modifierColor
+    },
+    modifiernames () {
+      const names = []
+      for (const channel of this.channels) {
+        for (const sample of channel.samples) {
+          for (const modifier of sample.modifiers) {
+            if (names.includes(modifier.name)) { continue }
+            names.push(modifier.name)
+          }
+        }
+      }
+      return names
+    },
+    modifiertypes () {
+      // for each region, we need a list of samples of the form [ {name=samplename, types={modifiername=modifiertype}}]
+      // modifiertype is to be set to none if the modifier is not available for a specific process
+      // an additional check is necessary for modifiers of type histo+normsys
+      const regions = {}
+      for (const channel of this.channels) {
+        const samples = Array.from({ length: channel.samples.length }, u => ({}))
+        let sampleindex = 0
+        for (const sample of channel.samples) {
+          const sampleObject = {}
+          sampleObject.name = sample.name
+          const types = {}
+          // first, set all modifier types to 'none'
+          for (const modifiername of this.modifiernames) {
+            types[modifiername] = 'none'
+          }
+          // then, change those that do exist for a specific sample
+          for (const modifier of sample.modifiers) {
+            // need to be careful with modifiers that are both histosys and normsys
+            if (types[modifier.name] === 'histosys' && modifier.type === 'normsys') {
+              types[modifier.name] = 'normhisto'
+              continue
+            }
+            if (types[modifier.name] === 'normsys' && modifier.type === 'histosys') {
+              types[modifier.name] = 'normhisto'
+              continue
+            }
+            // else everything can proceed as usual
+            types[modifier.name] = modifier.type
+          }
+          sampleObject.types = types
+          samples[sampleindex] = sampleObject
+          sampleindex++
+        }
+        regions[channel.name] = samples
+      }
+      return regions
+    }
+  }
+}
+</script>

--- a/src/components/ModifierStructurePlot.vue
+++ b/src/components/ModifierStructurePlot.vue
@@ -1,13 +1,19 @@
 <template>
-  <template v-for="channel in channels" :key="channel.name">
+  <template v-for="(channel, channelIndex) in channels" :key="channel.name">
     <h2>{{channel.name}}</h2>
-    <svg :height="length*modifiertypes[channel.name].length" :width="length*modifiernames.length">
-      <template v-for="(process, processIndex) in modifiertypes[channel.name]" :key="process.name">
-        <rect v-for="(modifiername, modifierIndex) in modifiernames" :key="modifiername" :height="length" :width="length" :x="modifierIndex*length" :y="processIndex*length" :fill="colors[process.types[modifiername]]"/>
-      </template>
-    </svg>
-    <hr />
+    <g>
+      <svg :height="length*modifiertypes[channel.name].length" :width="length*modifiernames.length">
+        <template v-for="(process, processIndex) in modifiertypes[channel.name]" :key="process.name">
+          <rect v-for="(modifiername, modifierIndex) in modifiernames" :key="modifiername" :height="length" :width="length" :x="modifierIndex*length" :y="processIndex*length" :fill="colors[process.types[modifiername]]"/>
+        </template>
+        <path fill="none" stroke="#000" :d="pathStringX[channelIndex]"></path>
+        <path fill="none" stroke="#000" :d="pathStringY[channelIndex]"></path>
+      </svg>
+    </g>
   </template>
+  <svg height="300" :width="length*modifiernames.length">
+    <text v-for="(modifiername, modifierIndex) in modifiernames" :key="modifiername" :x="0" :y="modifierIndex*this.length+0.5*this.length" transform="rotate(-90)" dominant-baseline="middle" text-anchor="end">{{modifiername}}</text>
+  </svg>
 </template>
 
 <script>
@@ -17,7 +23,8 @@ export default {
   },
   data () {
     return {
-      length: 20
+      length: 20,
+      ticklength: 5
     }
   },
   computed: {
@@ -34,6 +41,37 @@ export default {
         normfactor: 'rgb(213,94,0)' // vermilion
       }
       return modifierColor
+    },
+    pathStringX () {
+      const strings = Array.from({ length: this.channels.length }, u => (''))
+      let channelIndex = 0
+      for (const channel of this.channels) {
+        const yCoordinate = this.length * channel.samples.length
+        let string = 'M' + 0 + ',' + yCoordinate
+        for (let i = 1; i <= this.modifiernames.length; i++) {
+          string += 'H' + i * this.length
+          string += 'V' + (yCoordinate - this.ticklength)
+          string += 'M' + i * this.length + ',' + yCoordinate
+        }
+        strings[channelIndex] = string
+        channelIndex++
+      }
+      return strings
+    },
+    pathStringY () {
+      const strings = Array.from({ length: this.channels.length }, u => (''))
+      let channelIndex = 0
+      for (const channel of this.channels) {
+        let string = 'M' + 0 + ',' + 0
+        for (let i = 1; i <= channel.samples.length; i++) {
+          string += 'V' + (this.length * i)
+          string += 'H' + (this.ticklength)
+          string += 'M' + 0 + ',' + (this.length * i)
+        }
+        strings[channelIndex] = string
+        channelIndex++
+      }
+      return strings
     },
     modifiernames () {
       const names = []

--- a/src/components/ModifierStructurePlot.vue
+++ b/src/components/ModifierStructurePlot.vue
@@ -1,4 +1,12 @@
 <template>
+  <svg :height="length+20" :width="horizontalOffset+Object.keys(colors).length*175">
+    <g :transform="`translate(${horizontalOffset}, 0)`">
+      <template v-for="(color, colorindex) in Object.keys(colors)" :key="color">
+        <rect :height="length" :width="length" :fill="colors[color]" stroke="black" :y="0" :x="colorindex*175"/>
+        <text :y="0" :x="25+colorindex*175" dominant-baseline="hanging" text-anchor="begin">{{modifierStrings[color]}}</text>
+      </template>
+    </g>
+  </svg>
   <template v-for="(channel, channelIndex) in channels" :key="channel.name">
     <h2>{{channel.name}}</h2>
     <svg :height="length*modifiertypes[channel.name].length" :width="horizontalOffset+length*modifiernames.length+50">
@@ -42,12 +50,24 @@ export default {
         staterror: 'rgb(230,159,0)', // orange
         normsys: 'rgb(86,180,233)', // sky blue
         histosys: 'rgb(240,228,66)', // yellow
-        none: 'rgb(255,255,255)', // white
-        normhisto: 'rgb(0,158,115)', // blueish green
         shapesys: 'rgb(204,121,167)', // reddish purple
-        normfactor: 'rgb(213,94,0)' // vermilion
+        normhisto: 'rgb(0,158,115)', // blueish green
+        normfactor: 'rgb(213,94,0)', // vermilion
+        none: 'rgb(255,255,255)' // white
       }
       return modifierColor
+    },
+    modifierStrings () {
+      return {
+        lumi: 'lumi',
+        staterror: 'staterror',
+        normsys: 'normsys',
+        histosys: 'histosys',
+        shapesys: 'shapesys',
+        normhisto: 'histosys+normsys',
+        normfactor: 'normfactor',
+        none: 'none'
+      }
     },
     pathStringX () {
       const strings = Array.from({ length: this.channels.length }, u => (''))

--- a/src/components/ModifierStructurePlot.vue
+++ b/src/components/ModifierStructurePlot.vue
@@ -1,30 +1,34 @@
 <template>
-  <svg :height="length+20" :width="horizontalOffset+Object.keys(colors).length*175">
-    <g :transform="`translate(${horizontalOffset}, 0)`">
-      <template v-for="(color, colorindex) in Object.keys(colors)" :key="color">
-        <rect :height="length" :width="length" :fill="colors[color]" stroke="black" :y="0" :x="colorindex*175"/>
-        <text :y="0" :x="25+colorindex*175" dominant-baseline="hanging" text-anchor="begin">{{modifierStrings[color]}}</text>
-      </template>
-    </g>
-  </svg>
-  <template v-for="(channel, channelIndex) in channels" :key="channel.name">
-    <h2>{{channel.name}}</h2>
-    <svg :height="length*modifiertypes[channel.name].length" :width="horizontalOffset+length*modifiernames.length+50">
+  <div class="modifierstructure">
+    <svg :height="length+20" :width="horizontalOffset+Object.keys(colors).length*175">
       <g :transform="`translate(${horizontalOffset}, 0)`">
-        <template v-for="(process, processIndex) in modifiertypes[channel.name]" :key="process.name">
-          <rect v-for="(modifiername, modifierIndex) in modifiernames" :key="modifiername" :class="{ isnothighlighted: !rectisHighlighted(processIndex, channelIndex, modifierIndex) }" :height="length" :width="length" :x="modifierIndex*length" :y="processIndex*length" :fill="colors[process.types[modifiername]]" @mouseover="highlight(processIndex, channelIndex, modifierIndex)" @mouseleave="unhighlight"/>
+        <template v-for="(color, colorindex) in Object.keys(colors)" :key="color">
+          <rect :height="length" :width="length" :fill="colors[color]" stroke="black" :y="0" :x="colorindex*175"/>
+          <text :y="0" :x="25+colorindex*175" dominant-baseline="hanging" text-anchor="begin">{{modifierStrings[color]}}</text>
         </template>
-        <path fill="none" stroke="#000" :d="pathStringX[channelIndex]"></path>
-        <path fill="none" stroke="#000" :d="pathStringY[channelIndex]"></path>
       </g>
-      <text v-for="(process, processIndex) in modifiertypes[channel.name]" :key="process.name" :class="{ isnothighlighted: !processisHighlighted(processIndex, channelIndex) }" :x="0" :y="processIndex*length+length">{{process.name}}</text>
     </svg>
-  </template>
-  <svg height="300" :width="horizontalOffset+length*modifiernames.length+50">
-    <g :transform="`translate(${horizontalOffset}, 0)`">
-      <text v-for="(modifiername, modifierIndex) in modifiernames" :key="modifiername" :class="{ isnothighlighted: !modifierisHighlighted(modifierIndex) }" :x="0" :y="modifierIndex*length+0.5*length" transform="rotate(-90)" dominant-baseline="middle" text-anchor="end">{{modifiername}}</text>
-  </g>
-  </svg>
+    <template v-for="(channel, channelIndex) in channels" :key="channel.name">
+      <h2>{{channel.name}}</h2>
+      <svg :height="length*modifiertypes[channel.name].length" :width="horizontalOffset+length*modifiernames.length+50">
+        <g :transform="`translate(${horizontalOffset}, 0)`">
+          <template v-for="(process, processIndex) in modifiertypes[channel.name]" :key="process.name">
+            <template v-for="(modifiername, modifierIndex) in modifiernames" :key="modifiername">
+              <rect :class="{ isnothighlighted: !rectisHighlighted(processIndex, channelIndex, modifierIndex), ispassive: isPassive(processIndex, channelIndex, modifierIndex) }" :height="length" :width="length" :x="modifierIndex*length" :y="processIndex*length" :fill="colors[process.types[modifiername]]" @mouseover="highlight(processIndex, channelIndex, modifierIndex)" @mouseleave="unhighlight"/>
+            </template>
+          </template>
+          <path fill="none" stroke="#000" :d="pathStringX[channelIndex]"></path>
+          <path fill="none" stroke="#000" :d="pathStringY[channelIndex]"></path>
+        </g>
+        <text v-for="(process, processIndex) in modifiertypes[channel.name]" :key="process.name" :class="{ isnothighlighted: !processisHighlighted(processIndex, channelIndex) }" :x="0" :y="processIndex*length+length">{{process.name}}</text>
+      </svg>
+    </template>
+    <svg height="300" :width="horizontalOffset+length*modifiernames.length+50">
+      <g :transform="`translate(${horizontalOffset}, 0)`">
+        <text v-for="(modifiername, modifierIndex) in modifiernames" :key="modifiername" :class="{ isnothighlighted: !modifierisHighlighted(modifierIndex) }" :x="0" :y="modifierIndex*length+0.5*length" transform="rotate(-90)" dominant-baseline="middle" text-anchor="end">{{modifiername}}</text>
+    </g>
+    </svg>
+  </div>
 </template>
 
 <script>
@@ -110,6 +114,7 @@ export default {
           }
         }
       }
+      names.sort()
       return names
     },
     modifiertypes () {
@@ -164,6 +169,11 @@ export default {
       return (processindex, channelindex, modifierindex) => {
         return ((this.highlightedProcess === '' && this.highlightedChannel === '' && this.highlightedModifier === '') || (this.highlightedProcess === this.channels[channelindex].samples[processindex].name && this.highlightedChannel === this.channels[channelindex].name && this.highlightedModifier === this.modifiernames[modifierindex]))
       }
+    },
+    isPassive () {
+      return (processindex, channelindex, modifierindex) => {
+        return ((this.highlightedProcess === this.channels[channelindex].samples[processindex].name && this.highlightedChannel === this.channels[channelindex].name) || (this.highlightedModifier === this.modifiernames[modifierindex]))
+      }
     }
   },
   methods: {
@@ -182,12 +192,21 @@ export default {
 </script>
 
 <style>
+  rect{
+    stroke-width: 2;
+  }
+  rect.ispassive{
+    stroke: red;
+  }
   rect.isnothighlighted{
     fill-opacity:0.5;
-    transition: fill-opacity 0.5s ease;
+    stroke-opacity: 0.3;
+    stroke-width: 1;
   }
   text.isnothighlighted{
     fill: grey;
-    transition: fill 0.5s ease;
+  }
+  .modifierstructure{
+    overflow-x: scroll;
   }
 </style>


### PR DESCRIPTION
This adds a visualization of a model's modifier structure, following what was implemented in https://github.com/scikit-hep/cabinetry/issues/332