### PR TITLE
Allow reading workspaces from HEPData

### DIFF
--- a/src/components/AnalysesList.vue
+++ b/src/components/AnalysesList.vue
@@ -7,7 +7,7 @@ export default {
   data () {
     return {
       workspaces: [],
-      hepdataid: '2077557'
+      hepdataid: ''
     }
   },
   methods: {
@@ -32,6 +32,7 @@ export default {
       reader.readAsText(file)
     },
     readFileFromHEPData: async function () {
+      if (this.hepdataid === '') { return }
       const hepdataurl = 'https://www.hepdata.net/record/ins' + this.hepdataid + '?format=json'
       const hepdataentry = await (await fetch(hepdataurl)).json()
       console.log(hepdataentry)
@@ -48,9 +49,6 @@ export default {
     deleteWorkspace: function (index) {
       this.workspaces.splice(index, 1)
     }
-  },
-  beforeMount () {
-    this.readFileFromHEPData()
   }
 }
 </script>
@@ -73,9 +71,9 @@ export default {
       </div>
       <span>or</span>
       <div class="input-group mb-3">
-        <input type="text" class="form-control" placeholder="HEPdata ID" aria-label="HEPdata ID" aria-describedby="button-addon2">
+        <input type="text" class="form-control" v-model="hepdataid" placeholder="HEPdata ID" aria-label="HEPdata ID" aria-describedby="button-addon2">
         <div class="addbutton">
-          <button class="btn btn-outline-primary btn-lg" type="button" id="button-addon2">Add From HEPdata</button>
+          <button class="btn btn-outline-primary btn-lg" type="button" id="button-addon2" @click="readFileFromHEPData">Add From HEPdata</button>
         </div>
       </div>
     </div>

--- a/src/components/AnalysesList.vue
+++ b/src/components/AnalysesList.vue
@@ -6,7 +6,8 @@ export default {
   },
   data () {
     return {
-      workspaces: []
+      workspaces: [],
+      hepdataid: '2077557'
     }
   },
   methods: {
@@ -30,9 +31,26 @@ export default {
       }
       reader.readAsText(file)
     },
+    readFileFromHEPData: async function () {
+      const hepdataurl = 'https://www.hepdata.net/record/ins' + this.hepdataid + '?format=json'
+      const hepdataentry = await (await fetch(hepdataurl)).json()
+      console.log(hepdataentry)
+      const analyses = hepdataentry.record.analyses.filter(analysis => analysis.type === 'HistFactory')
+      let hepdataIndex = 1
+      for (const analysis of analyses) {
+        const response = await (await fetch(analysis.analysis.replace('landing_page=true', 'format=json'))).json()
+        const workspace = JSON.parse(response.file_contents)
+        console.log(workspace)
+        this.workspaces.push({ name: 'HEPdata ID: ' + this.hepdataid + ', workspace: ' + hepdataIndex, workspace })
+        hepdataIndex++
+      }
+    },
     deleteWorkspace: function (index) {
       this.workspaces.splice(index, 1)
     }
+  },
+  beforeMount () {
+    this.readFileFromHEPData()
   }
 }
 </script>
@@ -50,8 +68,15 @@ export default {
       <div class="addbutton">
         <label class="btn btn-outline-primary btn-lg">
             <input type="file" @change="loadFiles" multiple/>
-            Add New Workspaces
+            Add From Local Input
         </label>
+      </div>
+      <span>or</span>
+      <div class="input-group mb-3">
+        <input type="text" class="form-control" placeholder="HEPdata ID" aria-label="HEPdata ID" aria-describedby="button-addon2">
+        <div class="addbutton">
+          <button class="btn btn-outline-primary btn-lg" type="button" id="button-addon2">Add From HEPdata</button>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- [ ] workspaces are currently listed by their HEPData ID and the index of the workspace. It would be more descriptive to use the file name instead.
- [ ] workspaces may take a while to load; a progress bar should be shown to indicate this 
- [x] error handling is needed in case an invalid HEPData ID is entered or when a HEPData entry does not have associated workspaces