### PR TITLE
Use skeletons as placeholders while workspaces are loaded

### DIFF
--- a/src/components/WorkspaceDetailView.vue
+++ b/src/components/WorkspaceDetailView.vue
@@ -31,11 +31,16 @@ const height = computed(() => {
 <template>
   <q-card flat bordered style="padding: 1em, width: calc(100vw-2em);">
     <q-card-section>
-      <h2>{{ workspace_store.name }}</h2>
+      <q-skeleton v-if="workspace_store.loading" height="4em"></q-skeleton>
+      <h2 v-else>{{ workspace_store.name }}</h2>
     </q-card-section>
     <q-separator inset></q-separator>
     <!-- extra if condition needed to ensure data is not accessed before it is actually available in the store -->
-    <div v-if="workspace_store.workspace.channels !== undefined" class="column">
+    <q-skeleton v-if="workspace_store.loading" height="12em"></q-skeleton>
+    <div
+      v-else-if="workspace_store.workspace.channels !== undefined"
+      class="column"
+    >
       <q-expansion-item switch-toggle-side default-opened label="Summary">
         <div class="row justify-around">
           <div class="col-3">

--- a/src/components/WorkspaceListItem.vue
+++ b/src/components/WorkspaceListItem.vue
@@ -1,44 +1,69 @@
 <script setup lang="ts">
-    import { ref, reactive, nextTick } from 'vue'
-    import { QPopupEdit } from 'quasar';
-    import { useWorkspaceStore } from '../stores/workspace'
+import { ref, reactive, nextTick } from 'vue';
+import { QPopupEdit } from 'quasar';
+import { useWorkspaceStore } from '../stores/workspace';
 
-    const props = defineProps<{
-        id: number
-    }>()
+const props = defineProps<{
+  id: number;
+}>();
 
-    const workspace_store = useWorkspaceStore(props.id)()
+const workspace_store = useWorkspaceStore(props.id)();
 
-    const popup = ref<InstanceType<typeof QPopupEdit>>()
+const popup = ref<InstanceType<typeof QPopupEdit>>();
 
-    const state = reactive({ popup_disabled: true })
+const state = reactive({ popup_disabled: true });
 
-    async function edit_workspace_name(): Promise<void> {
-        enable_popup()
-        await nextTick()
-        popup.value?.show()
-    }
-    function disable_popup(): void {
-        state.popup_disabled = true
-    }
-    function enable_popup(): void {
-        state.popup_disabled = false
-    }
+async function edit_workspace_name(): Promise<void> {
+  enable_popup();
+  await nextTick();
+  popup.value?.show();
+}
+function disable_popup(): void {
+  state.popup_disabled = true;
+}
+function enable_popup(): void {
+  state.popup_disabled = false;
+}
 </script>
 
 <template>
-    <q-item>
-        <q-item-section>
-            {{  workspace_store.name }}
-            <q-popup-edit :disable="state.popup_disabled" ref="popup" v-model="workspace_store.name" auto-save v-slot="scope" @hide="disable_popup">
-                <q-input v-model="scope.value" dense autofocus @keyup.enter="scope.set"></q-input>
-            </q-popup-edit>
-        </q-item-section>
-        <q-item-section side top>
-            <q-btn @click="edit_workspace_name()" icon="edit"/>
-        </q-item-section>
-        <q-item-section side bottom>
-            <q-btn @click="workspace_store.delete_workspace()" icon="delete"/>
-        </q-item-section>
-    </q-item>
+  <q-item>
+    <q-item-section>
+      <div v-if="workspace_store.loading">
+        <q-skeleton type="text"></q-skeleton>
+      </div>
+      <div v-else>
+        {{ workspace_store.name }}
+        <q-popup-edit
+          :disable="state.popup_disabled"
+          ref="popup"
+          v-model="workspace_store.name"
+          auto-save
+          v-slot="scope"
+          @hide="disable_popup"
+        >
+          <q-input
+            v-model="scope.value"
+            dense
+            autofocus
+            @keyup.enter="scope.set"
+          ></q-input>
+        </q-popup-edit>
+      </div>
+    </q-item-section>
+    <q-item-section side top>
+      <q-btn
+        :disable="workspace_store.loading"
+        @click="edit_workspace_name()"
+        icon="edit"
+      />
+    </q-item-section>
+    <q-item-section side bottom>
+      <q-btn
+        :disable="workspace_store.loading"
+        @click="workspace_store.delete_workspace()"
+        icon="delete"
+      />
+    </q-item-section>
+  </q-item>
 </template>

--- a/src/components/WorkspaceListItem.vue
+++ b/src/components/WorkspaceListItem.vue
@@ -30,7 +30,7 @@ function enable_popup(): void {
   <q-item>
     <q-item-section>
       <div v-if="workspace_store.loading">
-        <q-skeleton type="text"></q-skeleton>
+        <q-skeleton type="text" width="75px"></q-skeleton>
       </div>
       <div v-else>
         {{ workspace_store.name }}

--- a/src/stores/workspace.ts
+++ b/src/stores/workspace.ts
@@ -21,6 +21,7 @@ export const useWorkspaceStore = function (id: number) {
       channel_title_index: {} as { [key: string]: string },
       process_color_index: {} as { [key: string]: string },
       download_urls: {} as { [key: string]: string },
+      loading: true as boolean,
     }),
     getters: {
       process_names(): string[] {
@@ -325,6 +326,7 @@ export const useWorkspaceStore = function (id: number) {
           }
         };
         reader.readAsText(file);
+        this.loading = false;
       },
       async load_workspace_from_HEPdata(
         analysis: IHEPdataanalysis,
@@ -342,12 +344,14 @@ export const useWorkspaceStore = function (id: number) {
         const workspace = JSON.parse(response.file_contents);
         this.workspace = workspace;
         this.name = 'HEPdataID' + hepdata_id + 'WS' + ws_index;
+        this.loading = false;
       },
       delete_workspace(): void {
         const storeid = useStoreIDStore();
         storeid.remove_store_with_id(id);
         this.workspace = {} as IWorkspace;
         this.name = '';
+        this.loading = true;
       },
       set_svg_url(svg_id: string): void {
         const svg = document.getElementById('svg_' + svg_id);


### PR DESCRIPTION
Placeholders are shown in the workspace list and on the individual workspace cards while workspaces are being loaded to show the user that tasks are running in the background.