### PR TITLE
Popup window when loading workspaces from HEPdata

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -19,6 +19,11 @@ export interface IAnalysis {
   url: string;
 }
 
+export interface IAnalysisOption {
+  label: string;
+  value: IAnalysis;
+}
+
 export interface IProcess {
   name: string;
   data: number[];

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,10 +1,22 @@
 export interface IHEPdataentry {
   record: { analyses: IHEPdataanalysis[] };
+  resources_with_doi: IDOIentry[];
+}
+
+export interface IDOIentry {
+  description: string;
+  filename: string;
+  doi: string;
 }
 
 export interface IHEPdataanalysis {
   type: string;
   analysis: string;
+}
+
+export interface IAnalysis {
+  name: string;
+  url: string;
 }
 
 export interface IProcess {

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -30,7 +30,7 @@ const route = useRoute();
 
 onMounted(() => {
   if (route.query.id) {
-    store_id_store.load_workspaces_from_HEPdata(route.query.id as string);
+    store_id_store.check_workspaces_on_HEPdata(route.query.id as string);
   }
 });
 </script>

--- a/src/stores/storeid.ts
+++ b/src/stores/storeid.ts
@@ -7,6 +7,7 @@ export const useStoreIDStore = defineStore('storeids', {
   state: () => ({
     ids: [] as number[],
     free_ids: [] as number[],
+    checking: false as boolean,
   }),
   actions: {
     load_workspaces_from_local_files(files: FileList): void {
@@ -19,6 +20,7 @@ export const useStoreIDStore = defineStore('storeids', {
     async check_workspaces_on_HEPdata(
       hepdata_id: string
     ): Promise<IAnalysis[]> {
+      this.checking = true;
       const hepdata_url =
         'https://www.hepdata.net/record/ins' +
         hepdata_id +
@@ -61,6 +63,7 @@ export const useStoreIDStore = defineStore('storeids', {
         });
         return [];
       }
+      this.checking = false;
       return analyses;
     },
     async load_workspaces_from_HEPdata(analyses: IAnalysis[]): Promise<void> {

--- a/src/stores/workspace.ts
+++ b/src/stores/workspace.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia';
 import { useStoreIDStore } from './storeid';
 import type {
-  IHEPdataanalysis,
+  IAnalysis,
   IStackedChannel,
   IStackedChannelBinwise,
   IStackedProcess,
@@ -328,22 +328,15 @@ export const useWorkspaceStore = function (id: number) {
         reader.readAsText(file);
         this.loading = false;
       },
-      async load_workspace_from_HEPdata(
-        analysis: IHEPdataanalysis,
-        hepdata_id: string,
-        ws_index: number
-      ): Promise<void> {
+      async load_workspace_from_HEPdata(analysis: IAnalysis): Promise<void> {
         const response = await (
           await fetch(
-            analysis.analysis.replace(
-              'landing_page=true',
-              'format=json&light=true'
-            )
+            analysis.url.replace('landing_page=true', 'format=json&light=true')
           )
         ).json();
         const workspace = JSON.parse(response.file_contents);
         this.workspace = workspace;
-        this.name = 'HEPdataID' + hepdata_id + 'WS' + ws_index;
+        this.name = analysis.name;
         this.loading = false;
       },
       delete_workspace(): void {


### PR DESCRIPTION
Clicking on the "Read from HEPdata" button triggers a popup displaying a list of the available JSON workspaces. This allows the user to select only the workspaces of interest. By default, all available workspaces are selected.