### PR TITLE
Provide example workspace for showcasing the site

### DIFF
--- a/src/components/WorkspaceLoader.vue
+++ b/src/components/WorkspaceLoader.vue
@@ -48,6 +48,12 @@ async function load_workspaces(): Promise<void> {
   popup.value?.hide();
   hepdata_id.value = '';
 }
+
+async function on_example_click(): Promise<void> {
+  const url =
+    'https://raw.githubusercontent.com/vaustrup/WorkspaceExplorer/main/tests/example_workspace.json';
+  storeid_store.load_workspace_from_url(url, 'Example');
+}
 </script>
 
 <template>
@@ -98,6 +104,8 @@ async function load_workspaces(): Promise<void> {
         </q-popup-proxy>
       </q-btn>
     </div>
+    <span style="margin: 1em">or</span>
+    <q-btn @click="on_example_click()"> Try an example </q-btn>
   </div>
 </template>
 

--- a/src/stores/storeid.ts
+++ b/src/stores/storeid.ts
@@ -17,6 +17,11 @@ export const useStoreIDStore = defineStore('storeids', {
         workspace_store.load_workspace_from_local_file(f);
       }
     },
+    async load_workspace_from_url(url: string, name?: string): Promise<void> {
+      const id = this.add_store_with_id();
+      const workspace_store = useWorkspaceStore(id)();
+      workspace_store.load_workspace_from_url(url, name);
+    },
     async check_workspaces_on_HEPdata(
       hepdata_id: string
     ): Promise<IAnalysis[]> {

--- a/src/stores/workspace.ts
+++ b/src/stores/workspace.ts
@@ -334,6 +334,16 @@ export const useWorkspaceStore = function (id: number) {
         reader.readAsText(file);
         this.loading = false;
       },
+      async load_workspace_from_url(url: string, name?: string): Promise<void> {
+        const response = await (await fetch(url)).json();
+        this.workspace = response;
+        if (name === undefined) {
+          this.name = url;
+        } else {
+          this.name = name;
+        }
+        this.loading = false;
+      },
       async load_workspace_from_HEPdata(analysis: IAnalysis): Promise<void> {
         const response = await (
           await fetch(


### PR DESCRIPTION
Add button to read an example workspace. The workspace is loaded from tests/example_workspace.json in the GitHub repository.