### PR TITLE
Adapt to changes in HEPData providing large workspace files

### DIFF
--- a/src/components/WorkspaceLoader.vue
+++ b/src/components/WorkspaceLoader.vue
@@ -2,6 +2,7 @@
 import { ref, computed } from 'vue';
 import { useStoreIDStore } from 'src/stores/storeid';
 import { Notify, QFile, QPopupProxy } from 'quasar';
+import { check_workspaces_on_HEPdata, load_workspaces_from_HEPdata } from 'src/core/hepdata';
 import type { IAnalysis, IAnalysisOption } from 'src/interfaces';
 
 const storeid_store = useStoreIDStore();
@@ -34,7 +35,7 @@ function get_file(): void {
 }
 
 async function on_click(): Promise<void> {
-  analyses.value = await storeid_store.check_workspaces_on_HEPdata(
+  analyses.value = await check_workspaces_on_HEPdata(
     hepdata_id.value
   );
   analyses_to_load = analyses.value.map((analysis) => {
@@ -44,7 +45,7 @@ async function on_click(): Promise<void> {
 }
 
 async function load_workspaces(): Promise<void> {
-  storeid_store.load_workspaces_from_HEPdata(analyses.value);
+  load_workspaces_from_HEPdata(analyses.value);
   popup.value?.hide();
   hepdata_id.value = '';
 }

--- a/src/core/hepdata.ts
+++ b/src/core/hepdata.ts
@@ -1,0 +1,64 @@
+import { useStoreIDStore } from 'src/stores/storeid';
+import { useWorkspaceStore } from 'src/stores/workspace';
+import type { IAnalysis, IHEPdataentry } from 'src/interfaces';
+import { Notify } from 'quasar';
+
+export async function check_workspaces_on_HEPdata(
+  hepdata_id: string
+): Promise<IAnalysis[]> {
+  const store_id_store = useStoreIDStore();
+  store_id_store.checking = true;
+  const hepdata_url =
+    'https://www.hepdata.net/record/ins' +
+    hepdata_id +
+    '?format=json&light=true';
+  let hepdata_entry: IHEPdataentry | null = null;
+  try {
+    hepdata_entry = await (await fetch(hepdata_url)).json();
+  } catch {
+    Notify.create({
+      message:
+        'Invalid JSON encountered. Are you sure you provided the correct HEPdata ID?',
+      color: 'negative',
+      icon: 'report_problem',
+      position: 'top',
+    });
+    return [];
+  }
+  const analyses: IAnalysis[] | undefined = [];
+  if (hepdata_entry?.record.analyses === undefined) {
+    return [];
+  }
+  let analysis_index = -1;
+  for (const analysis of hepdata_entry?.record.analyses) {
+    analysis_index++;
+    if (analysis.type !== 'HistFactory') {
+      continue;
+    }
+    analyses.push({
+      name: hepdata_entry.resources_with_doi[analysis_index].filename,
+      url: analysis.analysis,
+    });
+  }
+  if (analyses === undefined || analyses.length === 0) {
+    Notify.create({
+      message:
+        'No JSON workspaces are available for this HEPData entry. Are you sure you provided the correct HEPdata ID?',
+      color: 'negative',
+      icon: 'report_problem',
+      position: 'top',
+    });
+    return [];
+  }
+  store_id_store.checking = false;
+  return analyses;
+}
+
+export async function load_workspaces_from_HEPdata(analyses: IAnalysis[]): Promise<void> {
+  const store_id_store = useStoreIDStore();
+  for (const analysis of analyses) {
+    const id = store_id_store.add_store_with_id();
+    const workspace_store = useWorkspaceStore(id)();
+    workspace_store.load_workspace_from_HEPdata(analysis);
+  }
+}

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -22,18 +22,17 @@ import WorkspaceLoader from 'components/WorkspaceLoader.vue';
 import WorkspaceList from 'components/WorkspaceList.vue';
 import WorkspaceOverviewList from 'components/WorkspaceOverviewList.vue';
 import { useRoute } from 'vue-router';
-import { useStoreIDStore } from 'src/stores/storeid';
+import { check_workspaces_on_HEPdata, load_workspaces_from_HEPdata } from 'src/core/hepdata';
 import { onMounted } from 'vue';
 
-const store_id_store = useStoreIDStore();
 const route = useRoute();
 
 onMounted(async () => {
   if (route.query.id) {
-    const analyses = await store_id_store.check_workspaces_on_HEPdata(
+    const analyses = await check_workspaces_on_HEPdata(
       route.query.id as string
     );
-    store_id_store.load_workspaces_from_HEPdata(analyses);
+    load_workspaces_from_HEPdata(analyses);
   }
 });
 </script>

--- a/src/stores/storeid.ts
+++ b/src/stores/storeid.ts
@@ -1,7 +1,5 @@
 import { defineStore } from 'pinia';
 import { useWorkspaceStore } from 'src/stores/workspace';
-import type { IAnalysis, IHEPdataentry } from 'src/interfaces';
-import { Notify } from 'quasar';
 
 export const useStoreIDStore = defineStore('storeids', {
   state: () => ({
@@ -21,62 +19,6 @@ export const useStoreIDStore = defineStore('storeids', {
       const id = this.add_store_with_id();
       const workspace_store = useWorkspaceStore(id)();
       workspace_store.load_workspace_from_url(url, name);
-    },
-    async check_workspaces_on_HEPdata(
-      hepdata_id: string
-    ): Promise<IAnalysis[]> {
-      this.checking = true;
-      const hepdata_url =
-        'https://www.hepdata.net/record/ins' +
-        hepdata_id +
-        '?format=json&light=true';
-      let hepdata_entry: IHEPdataentry | null = null;
-      try {
-        hepdata_entry = await (await fetch(hepdata_url)).json();
-      } catch {
-        Notify.create({
-          message:
-            'Invalid JSON encountered. Are you sure you provided the correct HEPdata ID?',
-          color: 'negative',
-          icon: 'report_problem',
-          position: 'top',
-        });
-        return [];
-      }
-      const analyses: IAnalysis[] | undefined = [];
-      if (hepdata_entry?.record.analyses === undefined) {
-        return [];
-      }
-      let analysis_index = -1;
-      for (const analysis of hepdata_entry?.record.analyses) {
-        analysis_index++;
-        if (analysis.type !== 'HistFactory') {
-          continue;
-        }
-        analyses.push({
-          name: hepdata_entry.resources_with_doi[analysis_index].filename,
-          url: analysis.analysis,
-        });
-      }
-      if (analyses === undefined || analyses.length === 0) {
-        Notify.create({
-          message:
-            'No JSON workspaces are available for this HEPData entry. Are you sure you provided the correct HEPdata ID?',
-          color: 'negative',
-          icon: 'report_problem',
-          position: 'top',
-        });
-        return [];
-      }
-      this.checking = false;
-      return analyses;
-    },
-    async load_workspaces_from_HEPdata(analyses: IAnalysis[]): Promise<void> {
-      for (const analysis of analyses) {
-        const id = this.add_store_with_id();
-        const workspace_store = useWorkspaceStore(id)();
-        workspace_store.load_workspace_from_HEPdata(analysis);
-      }
     },
     remove_store_with_id(id: number): void {
       const index = this.ids.indexOf(id);

--- a/src/stores/workspace.ts
+++ b/src/stores/workspace.ts
@@ -182,11 +182,19 @@ export const useWorkspaceStore = function (id: number) {
       },
       async load_workspace_from_HEPdata(analysis: IAnalysis): Promise<void> {
         const response = await (
-          await fetch(
-            analysis.url.replace('landing_page=true', 'format=json&light=true')
-          )
-        ).json();
-        const workspace = JSON.parse(response.file_contents);
+          await fetch(analysis.url.replace('landing_page=true', 'format=json'))
+        ).json()
+        let workspace = {} as IWorkspace
+        if (response.file_contents === 'Large text file') {
+          workspace = await (
+            await fetch(
+              analysis.url.replace('landing_page=true', 'view=true')
+            )
+          ).json();
+        }
+        else {
+          workspace = JSON.parse(response.file_contents);
+        }
         this.workspace = workspace;
         this.name = analysis.name;
         this.loading = false;


### PR DESCRIPTION
Since https://github.com/HEPData/hepdata/pull/733 rendering of large text files is suppressed. In these cases, `file_contents` will contain the string "Large text file" and the contents of the file need to be fetched separately. This PR adds a check for this.

In addition, functionality to load from HEPData is moved out of the ID store.