### PR TITLE
Add inspire_id and resource_id as URL parameters

### DIFF
--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -22,7 +22,7 @@ import WorkspaceLoader from 'components/WorkspaceLoader.vue';
 import WorkspaceList from 'components/WorkspaceList.vue';
 import WorkspaceOverviewList from 'components/WorkspaceOverviewList.vue';
 import { useRoute } from 'vue-router';
-import { check_workspaces_on_HEPdata, load_workspaces_from_HEPdata } from 'src/core/hepdata';
+import { check_workspaces_on_HEPdata, load_workspaces_from_HEPdata, load_workspace_from_HEPdata_resource } from 'src/core/hepdata';
 import { onMounted } from 'vue';
 
 const route = useRoute();
@@ -33,6 +33,15 @@ onMounted(async () => {
       route.query.id as string
     );
     load_workspaces_from_HEPdata(analyses);
+  }
+  else if (route.query.inspire_id) {
+    const analyses = await check_workspaces_on_HEPdata(
+      route.query.inspire_id as string
+    );
+    load_workspaces_from_HEPdata(analyses);
+  }
+  else if (route.query.resource_id) {
+    load_workspace_from_HEPdata_resource(route.query.resource_id as string);
   }
 });
 </script>

--- a/src/stores/workspace.ts
+++ b/src/stores/workspace.ts
@@ -2,7 +2,6 @@ import { defineStore } from 'pinia';
 import { useStoreIDStore } from 'src/stores/storeid';
 import { useChannelStore } from 'src/stores/channel';
 import {
-  IAnalysis,
   IFitResults,
   INormFactor,
   ITaskResults,
@@ -167,7 +166,7 @@ export const useWorkspaceStore = function (id: number) {
       async load_workspace_from_local_file(file: File): Promise<void> {
         await this.get_file_contents(file);
         this.loading = false;
-        this.create_channel_stores(this.workspace);
+        this.create_channel_stores();
       },
       async load_workspace_from_url(url: string, name?: string): Promise<void> {
         const response = await (await fetch(url)).json();
@@ -178,36 +177,16 @@ export const useWorkspaceStore = function (id: number) {
           this.name = name;
         }
         this.loading = false;
-        this.create_channel_stores(this.workspace);
+        this.create_channel_stores();
       },
-      async load_workspace_from_HEPdata(analysis: IAnalysis): Promise<void> {
-        const response = await (
-          await fetch(analysis.url.replace('landing_page=true', 'format=json'))
-        ).json()
-        let workspace = {} as IWorkspace
-        if (response.file_contents === 'Large text file') {
-          workspace = await (
-            await fetch(
-              analysis.url.replace('landing_page=true', 'view=true')
-            )
-          ).json();
-        }
-        else {
-          workspace = JSON.parse(response.file_contents);
-        }
-        this.workspace = workspace;
-        this.name = analysis.name;
-        this.loading = false;
-        this.create_channel_stores(this.workspace);
-      },
-      create_channel_stores(workspace: IWorkspace): void {
+      create_channel_stores(): void {
         let channel_index = 0;
-        for (const channel of workspace.channels) {
+        for (const channel of this.workspace.channels) {
           const channel_store = useChannelStore(id, channel.name)();
           channel_store.name = channel.name;
           channel_store.samples = channel.samples;
           channel_store.observations =
-            workspace.observations[channel_index].data;
+            this.workspace.observations[channel_index].data;
           this.channels.push(channel_store);
           channel_index += 1;
         }


### PR DESCRIPTION
As pointed out by @GraemeWatt, the usage of `id` as URL parameter is not clear as it is not obvious which ID it refers to. To clarify, a `inspire_id` parameter is added which can be used in the same way as `id` previously. For compatibility, `id` also still works but will be deprecated. 

In addition, another URL parameter, `resource_id`, is implemented, which allows loading a specific workspace by giving its HEPData resource ID.

Closes #19