### PR TITLE
Fix workspace names when loading from HEPData via INSPIRE ID

### DIFF
--- a/src/core/hepdata.ts
+++ b/src/core/hepdata.ts
@@ -29,14 +29,12 @@ export async function check_workspaces_on_HEPdata(
   if (hepdata_entry?.record.analyses === undefined) {
     return [];
   }
-  let analysis_index = -1;
   for (const analysis of hepdata_entry?.record.analyses) {
-    analysis_index++;
     if (analysis.type !== 'HistFactory') {
       continue;
     }
     analyses.push({
-      name: hepdata_entry.resources_with_doi[analysis_index].filename,
+      name: analysis.filename,
       url: analysis.analysis,
     });
   }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,5 @@
 export interface IHEPdataentry {
   record: { analyses: IHEPdataanalysis[] };
-  resources_with_doi: IDOIentry[];
 }
 
 export interface IDOIentry {
@@ -12,6 +11,7 @@ export interface IDOIentry {
 export interface IHEPdataanalysis {
   type: string;
   analysis: string;
+  filename: string;
 }
 
 export interface IAnalysis {


### PR DESCRIPTION
Information about filenames is now available from HEPData, so we can retrieve the actual workspace names.

Closes #17 